### PR TITLE
[TASK] extend callback through passing the node details to the callback

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,24 +33,24 @@ const plugin = {
 
       if (handlers && handlers['show']) {
         opts.onShow = function () {
-          handlers['show'].fns()
+          handlers['show'].fns(vnode)
         }
       }
 
       if (handlers && handlers['shown']) {
         opts.onShown = function () {
-          handlers['shown'].fns()
+          handlers['shown'].fns(vnode)
         }
       }
       if (handlers && handlers['hidden']) {
         opts.onHidden = function () {
-          handlers['hidden'].fns()
+          handlers['hidden'].fns(vnode)
         }
       }
 
       if (handlers && handlers['hide']) {
         opts.onHide = function () {
-          handlers['hide'].fns()
+          handlers['hide'].fns(vnode)
         }
       }
 

--- a/src/index.js
+++ b/src/index.js
@@ -33,24 +33,24 @@ const plugin = {
 
       if (handlers && handlers['show']) {
         opts.onShow = function () {
-          handlers['show'].fns(vnode)
+          handlers['show'].fns(el, vnode)
         }
       }
 
       if (handlers && handlers['shown']) {
         opts.onShown = function () {
-          handlers['shown'].fns(vnode)
+          handlers['shown'].fns(el, vnode)
         }
       }
       if (handlers && handlers['hidden']) {
         opts.onHidden = function () {
-          handlers['hidden'].fns(vnode)
+          handlers['hidden'].fns(el, vnode)
         }
       }
 
       if (handlers && handlers['hide']) {
         opts.onHide = function () {
-          handlers['hide'].fns(vnode)
+          handlers['hide'].fns(el, vnode)
         }
       }
 


### PR DESCRIPTION
This PR extends the callbacks by passing the node infos to the callbacks.

This can be useful, for example if you want to do something with the button after a tooltip shows up.

In this example, i will add a active class to the tooltip trigger, to visualize the active element.

```html
<template>
  <button title="I'm called when a tooltip begins to show." @show="onShow" v-tippy>
    @show
  </button>
</template>

<script>
export default {
  methods: {
    onShow(node) {
      if (!node.elm.classList.contains('is-active')) {
        node.elm.classList.add('is-active')
      } else {
        node.elm.classList.remove('is-active');
      }
    }
  },
};
</script>
```

It would be great to get some feedback and please let me know if i should do something different or something else.