### PR TITLE
Add "delay" and "duration" props to v-tippy component

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -180,6 +180,15 @@ const plugin = {
           type: Number,
           default: 10
         },
+        
+        delay: {
+            type: [Number, Array],
+            default: [0, 20]
+        },
+        duration: {
+            type: [Number, Array],
+            default: [325, 275]
+        },
 
         offset: {
           type: Number,


### PR DESCRIPTION
Add support for "delay" and "duration" as properties on the `v-tippy` component, which I couldn't find a way to modify.