### PR TITLE
Use factory function for "delay" and "duration" default values

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -180,14 +180,14 @@ const plugin = {
           type: Number,
           default: 10
         },
-        
+
         delay: {
             type: [Number, Array],
-            default: [0, 20]
+            default: () => [0, 20]
         },
         duration: {
             type: [Number, Array],
-            default: [325, 275]
+            default: () => [325, 275]
         },
 
         offset: {


### PR DESCRIPTION
In development mode, Vue complains because object and array defaults for props must be returned from a factory function (https://vuejs.org/v2/guide/components-props.html#Prop-Validation)