### PR TITLE
Replace lodash with homemade functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,8 +90,6 @@
     ],
     "dependencies": {
         "humps": "^2.0.1",
-        "lodash.mapvalues": "^4.6.0",
-        "lodash.pickby": "^4.6.0",
         "tippy.js": "^4.2.1"
     }
 }


### PR DESCRIPTION
I'm not particularly happy of the Tippy + Popper bundle being whopping 32kB and this **wrapper package adding 47kB** is a joke.

PR **demonstrates** how you could reduce it's size by replacing `lodash.<module>` dependencies with functions crafted to your needs. It's still **enormous**, but the change shoved off roughly 20kB. If such replacement is no-no, consider at least replacing `lodash.<module>` with `lodash-es`, as `mapValues` and `pickBy` overlaps and `lodash-es` is more likely an existing dependency of final app than `lodash.<module>`.

For anyone willing to use it now in their webpack process (works for me, no test included / passed): 
`npm i Aareksio/vue-tippy#fix-module-size`
```js
import VueTippy, { TippyComponent } from 'vue-tippy/src/index';

Vue.use(VueTippy);
Vue.component("tippy", TippyComponent);
```