### PR TITLE
feat(component): allow extended with default values

### DIFF
--- a/src/components/Tippy.vue
+++ b/src/components/Tippy.vue
@@ -124,7 +124,7 @@ export default {
       return this.options;
     },
     getOptions() {
-      this.options = humps.camelizeKeys(this.$attrs);
+      Object.assign(this.options, humps.camelizeKeys(this.$attrs));
       this.filterOptions();
 
       if (!this.options.onShow && this.$listeners && this.$listeners["show"]) {


### PR DESCRIPTION
This feature allow us to extend the TippyComponent with default options : 

```
export default {
  extends: TippyComponent,
  data: () => ({
    options: {
      arrow: true,
      placement: 'bottom',
      theme: 'light,
    },
  }),
}
```