### PR TITLE
fixing typo of opening tag in Component: enabled and visible

### DIFF
--- a/docs/4.0/demo.md
+++ b/docs/4.0/demo.md
@@ -504,7 +504,7 @@ Attach many tippys to a single element.
 <div slot="code">
 
 ```html
-    <tippy to="visibleTest"  :visible="timer % 2 == 0" trigger="manual"> 
+    <tippy-v4 to="visibleTest"  :visible="timer % 2 == 0" trigger="manual"> 
         Visible 
     </tippy-v4>
     <button name="visibleTest" class="btn"> Visibile prop </button>

--- a/docs/4.0/demo.md
+++ b/docs/4.0/demo.md
@@ -504,9 +504,9 @@ Attach many tippys to a single element.
 <div slot="code">
 
 ```html
-    <tippy-v4 to="visibleTest"  :visible="timer % 2 == 0" trigger="manual"> 
+    <tippy to="visibleTest"  :visible="timer % 2 == 0" trigger="manual"> 
         Visible 
-    </tippy-v4>
+    </tippy>
     <button name="visibleTest" class="btn"> Visibile prop </button>
 ```
 </div>


### PR DESCRIPTION
The example contains the following typo : 

        <tippy to="visibleTest"  :visible="timer % 2 == 0" trigger="manual"> 
            Visible 
        </tippy-v4>

in this [section](https://kabbouchi.github.io/vue-tippy/4.0/demo.html#component-enabled-and-visible)