### PR TITLE
Add support to have an `arrow` modifier

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,12 +15,19 @@ const plugin = {
         (vnode.componentOptions && vnode.componentOptions.listeners)
 
       let opts = binding.value || {}
-      let modifiers = Object.keys(binding.modifiers || {});
+
+      const modifiers = Object.keys(binding.modifiers || {});
+      const placement = modifiers.find(modifier => modifier !== 'arrow');
+      const withArrow = modifiers.findIndex(modifier => modifier === 'arrow') !== -1;
 
       opts = Object.assign({}, options, opts)
 
-      if (modifiers.length) {
-        opts.placement = opts.placement || modifiers[0];
+      if (placement) {
+        opts.placement = opts.placement || placement;
+      }
+
+      if (withArrow) {
+        opts.arrow = opts.arrow !== undefined ? opts.arrow : true;
       }
 
       if (handlers && handlers['show']) {


### PR DESCRIPTION
Add support to have an arrow modifier like `v-tippy.arrow` and it will be the same of `v-tippy="{ arrow: true }"`.

It also support the placement modifier with the arrow one like `v-tippy.right.arrow`.