### PR TITLE
fix: invalid watch sources

### DIFF
--- a/src/components/Tippy.ts
+++ b/src/components/Tippy.ts
@@ -109,7 +109,7 @@ const TippyComponent = defineComponent({
       emit('state', unref(tippy.state))
     }, { immediate: true, deep: true })
 
-    watch(props, () => {
+    watch(() => props, () => {
       tippy.setProps(getOptions())
 
       if (slots.content)


### PR DESCRIPTION
Resolves the error: A watch source can only be a getter/effect function, a ref, a reactive object, or an array of these types.

```
[Vue warn]: Invalid watch source:  {
  appendTo: [Function: TIPPY_DEFAULT_APPEND_TO]
```