### PR TITLE
Support <tippy> as a child

### DIFF
--- a/docs/content/en/flavor/component.md
+++ b/docs/content/en/flavor/component.md
@@ -70,6 +70,20 @@ Mount tippy on the child node instead of default tag
   <template #content>Hi!</template>
 </tippy>
 ```
+
+### Example 3
+Tippy as a child using `to="parent"`. \
+Works like `:tag="null"`, but applies the tooltip to the parent element instead of the child.
+
+```html
+<button>
+  <tippy to="parent" content-tag="div" ontent-class="content-wrapper">
+    Hi!
+  </tippy>
+  Tippy!
+</button>
+```
+
 ## Singleton
 
 ### Example 1

--- a/playground/pages/Index.vue
+++ b/playground/pages/Index.vue
@@ -89,6 +89,33 @@
     </div>
 
     <div class="mt-6">
+      <span class="font-semibold mr-4">Tippy as a child component with prop content:</span>
+
+      <button class="text-sm py-2 px-3 bg-gray-900 text-white rounded-lg">
+        Hi
+        <tippy to="parent" content="Test"></tippy>
+      </button>
+    </div>
+
+    <div class="mt-6">
+      <span class="font-semibold mr-4">Tippy as a child component with #content template:</span>
+
+      <button class="text-sm py-2 px-3 bg-gray-900 text-white rounded-lg">
+        Hi
+        <tippy to="parent"><template #content>Test</template></tippy>
+      </button>
+    </div>
+
+    <div class="mt-6">
+      <span class="font-semibold mr-4">Tippy as a child component with direct content:</span>
+      
+      <button class="text-sm py-2 px-3 bg-gray-900 text-white rounded-lg">
+        Hi
+        <tippy to="parent">{{counter}} and counting</tippy>
+      </button>
+    </div>
+
+    <div class="mt-6">
       <span class="font-semibold mr-4">useTippy + callbacks(console.log):</span>
       <button
         class="text-sm py-2 px-3 bg-gray-900 text-white rounded-lg"

--- a/src/components/Tippy.ts
+++ b/src/components/Tippy.ts
@@ -115,12 +115,13 @@ const TippyComponent = defineComponent({
     }
 
     const tippy = useTippy(target, getOptions())
+    const contentSlot = slots.content
 
     onMounted(() => {
       mounted.value = true
 
       nextTick(() => {
-        if (slots.content)
+        if (contentSlot) 
           tippy.setContent(() => contentElem.value)
       })
     })
@@ -132,7 +133,7 @@ const TippyComponent = defineComponent({
     watch(() => props, () => {
       tippy.setProps(getOptions())
 
-      if (slots.content)
+      if (contentSlot)
         tippy.setContent(() => contentElem.value)
     }, { deep: true })
 
@@ -149,41 +150,33 @@ const TippyComponent = defineComponent({
       const slot = slots.default ? slots.default(exposed) : []
 
       const contentTag = typeof props.contentTag === 'string' ? props.contentTag as string : props.contentTag
+      const content = contentSlot
+        ? h(
+            contentTag,
+            {
+              ref: contentElem,
+              style: { display: mounted.value ? 'inherit' : 'none' },
+              class: props.contentClass,
+            },
+            contentSlot(exposed)
+          )
+        : null
 
       if (!props.tag) {
         const trigger = h(slot[0] as any, {
           ref: elem, 'data-v-tippy': ''
         });
 
-        return slots.content ?
-          [
-            trigger, h(
-              contentTag,
-              {
-                ref: contentElem,
-                style: { display: mounted.value ? 'inherit' : 'none' },
-                class: props.contentClass
-              },
-              slots.content(exposed)
-            )
-          ]
-          : trigger
+        return content ? [trigger, content] : trigger
       }
 
       const tag = typeof props.tag === 'string' ? props.tag as string : props.tag
 
-      return h(tag, { ref: elem, 'data-v-tippy': '' }, slots.content ? [
-        slot,
-        h(
-          contentTag,
-          {
-            ref: contentElem,
-            style: { display: mounted.value ? 'inherit' : 'none' },
-            class: props.contentClass
-          },
-          slots.content(exposed)
-        ),
-      ] : slot)
+      return h(
+        tag,
+        { ref: elem, 'data-v-tippy': '' },
+        content ? [slot, content] : slot
+      )
     }
   },
 })


### PR DESCRIPTION
This PR add the ["tippy component as a child" behavior](https://github.com/KABBOUCHI/vue-tippy/issues/123 ) from the 4.x version back.

It is slightly different from the old functionality, because this now requires the `to='parent'` prop to be set on the Tippy compoent.
This should make it easier to understand, where this tooltip belongs and also simplifies the implementation.

I like this "Tippy as a child" style, because in my mind a tooltip is just a small aspect of a component. "Hiding" it as a child seems nicer to me than having Tippy be the parent of the tooltipped element.
This also behaves like `:tag="null"`, i.e. not adding new DOM nodes under or around the tooltipped element. This helps with adding a tooltip without breaking existing styles.

There is some more technical details in the commit messages.

This change allows the following new ways of using Tippy:
```
<button>
  Click me!
  <tippy to="parent">
    I'm the tooltip
  </tippy>
</button>
```
or
```
<button>
  Click me!
  <tippy to="parent" content="I'm the tooltip"/>    
</button>
```
or
```
<button>
  Click me!
  <tippy to="parent">
    <template #content>
      I'm the tooltip
    </tooltip>
  </tippy>
</button>
```