### PR TITLE
fix(tippy-component): use Element constructor for to prop

### DIFF
--- a/src/components/Tippy.ts
+++ b/src/components/Tippy.ts
@@ -1,4 +1,4 @@
-import { defineComponent, ref, h, UnwrapNestedRefs, onMounted, nextTick, watch, unref, reactive, PropType } from 'vue'
+import { defineComponent, ref, h, UnwrapNestedRefs, onMounted, nextTick, watch, unref, reactive } from 'vue'
 import { TippyOptions } from '../types'
 import { useTippy } from '../composables'
 import tippy from 'tippy.js'
@@ -26,7 +26,7 @@ function unrefElement(elRef: any): any {
 const TippyComponent = defineComponent({
   props: {
     to: {
-      type: [String, Function] as PropType<string | Element>,
+      type: [String, Element],
     },
     tag: {
       type: [String, Object],


### PR DESCRIPTION
Using `Element` as the prop constructor should work just fine. The usage of `Function` constructor also causes Vue warnings, when an `Element` is provided as the value.

This way there is no longer need to cast the prop using `PropType<string | Element>`.