### PR TITLE
fix: augment `vue` rather than sub packages

### DIFF
--- a/src/components/Tippy.ts
+++ b/src/components/Tippy.ts
@@ -3,7 +3,7 @@ import { TippyOptions } from '../types'
 import { useTippy } from '../composables'
 import tippy from 'tippy.js'
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   interface ComponentCustomProps extends TippyOptions {
     to: string | Element
     tag: string


### PR DESCRIPTION
Description

As mentioned in [#28542](https://github.com/nuxt/nuxt/pull/28542), augmenting `vue` is the proper way to avoid type issues