### PR TITLE
fix: change augmentation module

### DIFF
--- a/src/components/TippySingleton.ts
+++ b/src/components/TippySingleton.ts
@@ -4,7 +4,7 @@ import { useSingleton } from '../composables'
 import { TippyOptions } from '../types'
 import tippy, { DefaultProps } from 'tippy.js'
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   interface ComponentCustomProps extends TippyOptions {}
 }
 


### PR DESCRIPTION
Hello, How is going?

Vue has changed the module name to augment.

https://vuejs.org/guide/typescript/options-api#augmenting-global-properties