### PR TITLE
feat: add support for vue components in useTippy

### DIFF
--- a/playground/pages/Index.vue
+++ b/playground/pages/Index.vue
@@ -189,6 +189,13 @@
     </div>
 
     <div class="mt-6">
+      <span class="font-semibold mr-4">useTippy + vue component:</span>
+      <UiButton ref="vueComponentButton">
+        Vue component Button
+      </UiButton>
+    </div>
+
+    <div class="mt-6">
       <span class="font-semibold mr-4"
         >Tippy component + change content and props realtime using component
         ref:</span
@@ -300,6 +307,7 @@ import {
 } from 'vue'
 import { useSingleton, useTippy, TippyOptions, TippyComponent } from '../../src'
 import Counter from '../components/Counter.vue'
+import UiButton from '../components/Button.vue'
 
 function useMousePosition() {
   const x = ref(0)
@@ -324,6 +332,7 @@ function useMousePosition() {
   }
 }
 export default defineComponent({
+  components: { UiButton },
   setup() {
     const counter = ref<number>(0)
 
@@ -396,6 +405,12 @@ export default defineComponent({
       content: 'Triggered by button7',
       placement: 'bottom',
       triggerTarget: button7,
+    })
+
+    const vueComponentButton = ref()
+
+    useTippy(vueComponentButton, {
+      content: 'Test Vue component',
     })
 
     const { x, y } = useMousePosition()
@@ -478,6 +493,7 @@ export default defineComponent({
       button6Inc,
       button7,
       target7,
+      vueComponentButton,
       tippyComponent1,
       log: console.log,
     }

--- a/src/composables/useTippy.ts
+++ b/src/composables/useTippy.ts
@@ -232,7 +232,8 @@ export function useTippy(
     if (typeof target === 'function') target = target()
 
     if (target) {
-      instance.value = tippy(target, getProps(opts))
+      //@ts-ignore
+      instance.value = tippy(target?.$el ?? target, getProps(opts))
       //@ts-ignore
       target.$tippy = response
     }


### PR DESCRIPTION
Added support for Vue components in `useTippy`.

There is now support for such tricks:
```
<template>
    <UiButton ref="button">
        Confirm
    </UiButton>
</template>
<script setup>
import { useTemplateRef } from 'vue';
import { useTippy } from 'vue-tippy';
import { UiButton } from '@/components/ui/UiButton.vue';

const button = useTemplateRef('button');

useTippy(button, { content: 'Test' });
</script>
```