### PR TITLE
fix: v-tippy not updating if content set to undefined

### DIFF
--- a/src/directive/index.ts
+++ b/src/directive/index.ts
@@ -68,6 +68,11 @@ const directive: Directive = {
 
   updated(el, binding) {
     const opts = typeof binding.value === "string" ? { content: binding.value } : binding.value || {}
+    
+    // any kind of falsy content value, even undefined, should be treated as null - 'no tooltip to show'
+    if (!opts.content) {
+      opts.content = null
+    }
 
     if (el.getAttribute('title') && !opts.content) {
       opts.content = el.getAttribute('title')


### PR DESCRIPTION
Repro steps:
1. set `v-tippy` directive to a `Ref<string | undefined>` w/ an initial value of a valid string (e.g. "test")
2. update the ref to be undefined
3. the tippy tooltip won't update - it'll ignore `content: undefined` and act as if the tooltip should still show "test"

This is because an undefined `content` will be ignored when `tippy.setProps()` is invoked. 